### PR TITLE
fix: update release workflow to trigger on main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
Corrects the branch name in release.yml from master to main.